### PR TITLE
Updated incorrect info in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Slot     |      Body       | Is displayed
 17       |    Off Hand     |   Yes
 18       |     Ranged      |   Yes
 19       |     Tabard      |   Yes
-20       |   Chest (new)   |   Yes
+20       |   Chest (Robe)  |   Yes
 21       | Main Hand (new) |   Yes
 22       | Off Hand (new)  |   Yes
 
@@ -283,9 +283,9 @@ Description     | Type
 :--------------:|:----:|
 NPC             |  8   | 
 Main Weapon     |  1   | 
-Off Weapon     |  1   | 
-Helmet     |  2   | 
-Shoulder | 4 | 
+Off Weapon      |  1   | 
+Helmet          |  2   | 
+Shoulder        |  4   | 
 
 
 


### PR DESCRIPTION
The difference between those two is that slot id `5` is for appearance models that only alter the upper (chest) area of character, while id `20` alters even the bottom (legs) area.

Also, you can find proof for this definition even in definitions for wow emulators and wow wiki.

